### PR TITLE
Add "support" (I think) for thin provisioning pools.

### DIFF
--- a/dump.php
+++ b/dump.php
@@ -48,6 +48,15 @@ foreach($data as $vgname => $value)
           $fpe    = $datavalues['start_extent'];
           $npe    = $datavalues['extent_count'] / $nparts;
 
+	  if($datavalues['type'] == 'thin-pool')
+	  {
+	    $nparts = 0;
+	  }
+	  if($datavalues['type'] == 'thin')
+	  {
+	    $nparts = 0;
+	  }
+
           for($n=0; $n < $nparts; ++$n)
           {
             $partcode = strtoupper(base_convert(10+$n,10,36));


### PR DESCRIPTION
Segments which are of type "thin-pool" are used to define thin provisioning
pools, which are composed of other ("normal") logical volumes. Segments of
type "thin" indicate they are stored in a thin pool. Neither type of segment
actually exists as a standalone physical segment that can/should be manipulated
by this utility.

My knowledge of PHP is limited to what I read in these scripts ;) but this
commit squelches output of thin entities by setting their segment count to 0
and appears to achieve the intended results.

Without this fix, dump.php would generate some entries for thin volumes and
rearrange.php would abort because no actual storage information appears for
them. After the fix, thin volumes do not appear in any output files and it
is possible to proceed with defragmentation.